### PR TITLE
Added support for ui-router anchor links

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -68,8 +68,14 @@ var renderAnchorLinkSymbol = function renderAnchorLinkSymbol(options) {
 var renderAnchorLink = function renderAnchorLink(anchor, options, tokens, idx) {
   var _tokens$children;
 
+  var hrefAttr = "href";
+  var hrefVal = "#" + anchor;
+  if (options.uiRouterLinks) {
+    hrefAttr = "ui-sref";
+    hrefVal = "{'#':'" + anchor + "'}";
+  }
   var linkTokens = [_extends({}, new Token("link_open", "a", 1), {
-    attrs: [["class", options.anchorClassName], ["href", "#" + anchor]]
+    attrs: [["class", options.anchorClassName], [hrefAttr, hrefVal]]
   })].concat(_toConsumableArray(renderAnchorLinkSymbol(options)), [new Token("link_close", "a", -1)]);
 
   // `push` or `unshift` according to anchorLinkBefore option
@@ -91,7 +97,11 @@ var treeToString = function treeToString(tree, options) {
   return tree.map(function (item) {
     var node = "\n" + repeat(options.indentation, indent) + "<li>";
     if (item.heading.content) {
-      node += "\n" + repeat(options.indentation, indent + 1) + ("<a href=\"#" + item.heading.anchor + "\">" + item.heading.content + "</a>");
+      if (!options.uiRouterLinks) {
+        node += "\n" + repeat(options.indentation, indent + 1) + ("<a href=\"#" + item.heading.anchor + "\">" + item.heading.content + "</a>");
+      } else {
+        node += "\n" + repeat(options.indentation, indent + 1) + ("<a ui-sref=\"{'#':'" + item.heading.anchor + "'}\">" + item.heading.content + "</a>");
+      }
     }
     if (item.nodes.length) {
       node += "\n" + repeat(options.indentation, indent + 1) + "<ul>" + treeToString(item.nodes, options, indent + 2) + ("\n" + repeat(options.indentation, indent + 1)) + "</ul>";
@@ -114,7 +124,8 @@ exports["default"] = function (md, options) {
     resetIds: true,
     indentation: "  ",
     anchorLinkSpace: true,
-    anchorLinkSymbolClassName: null
+    anchorLinkSymbolClassName: null,
+    uiRouterLinks: false
   }, options);
 
   var gstate = undefined;

--- a/src/index.js
+++ b/src/index.js
@@ -65,12 +65,18 @@ const renderAnchorLinkSymbol = (options) => {
 }
 
 const renderAnchorLink = (anchor, options, tokens, idx) => {
+  var hrefAttr = "href"
+  var hrefVal = `#${anchor}`
+  if (options.uiRouterLinks) {
+	hrefAttr = "ui-sref"
+	hrefVal = `{'#':'${anchor}'}`
+  }
   const linkTokens = [
     {
       ...(new Token("link_open", "a", 1)),
       attrs: [
         ["class", options.anchorClassName],
-        ["href", `#${anchor}`],
+        [hrefAttr, hrefVal],
       ],
     },
     ...(renderAnchorLinkSymbol(options)),
@@ -96,8 +102,14 @@ const renderAnchorLink = (anchor, options, tokens, idx) => {
 const treeToString = (tree, options, indent = 1) => tree.map(item => {
   let node = `\n${ repeat(options.indentation, indent) }<li>`
   if (item.heading.content) {
-    node += `\n${ repeat(options.indentation, indent + 1) }` +
-      `<a href="#${ item.heading.anchor }">${ item.heading.content }</a>`
+	if (!options.uiRouterLinks) {
+	  node += `\n${ repeat(options.indentation, indent + 1) }` +
+		`<a href="#${ item.heading.anchor }">${ item.heading.content }</a>`
+	}
+	else {
+	  node += `\n${ repeat(options.indentation, indent + 1) }` +
+		`<a ui-sref="{'#':'${ item.heading.anchor }'}">${ item.heading.content }</a>`
+	}
   }
   if (item.nodes.length) {
     node += `\n${ repeat(options.indentation, indent + 1) }` +
@@ -124,6 +136,7 @@ export default function(md, options) {
     indentation: "  ",
     anchorLinkSpace: true,
     anchorLinkSymbolClassName: null,
+	uiRouterLinks: false,
     ...options,
   }
 


### PR DESCRIPTION
Links are not always defined with the 'href' attribute on the <a> tag, especially in single page apps.

This commit adds the support for ui-router links (see [UI-Router](https://github.com/angular-ui/ui-router/wiki/Quick-Reference#ui-sref)).

Only change is an additional option key 'uiRouterLinks' which is 'false' by default (so there should be no backwards compatibility issues).

If it is set to 'true', a tag like:
```
<a href="#mwAnchor">
```
becomes:
```
<a ui-sref="{'#':'myAnchor'}">
```